### PR TITLE
mem: fix memory access for guests with >4GB RAM (close #3)

### DIFF
--- a/client.c
+++ b/client.c
@@ -44,8 +44,7 @@ int guest_client_new(char *ac, guest_access_t ty)
             if (libvirt_client_init(ac))
                 return -1;
             c->pid = libvirt_get_pid(ac);
-            libvirt_gpa2hva(0, &c->hva_base);
-            if (mem_init(c->pid, c->hva_base) == 0) {
+            if (mem_init(c->pid, libvirt_gpa2hva) == 0) {
                 c->readmem = mem_read;
             } else {
                 c->readmem = libvirt_readmem;
@@ -62,8 +61,7 @@ int guest_client_new(char *ac, guest_access_t ty)
             if (qmp_client_init(ac))
                 return -1;
             c->pid = qmp_get_pid(ac);
-            qmp_gpa2hva(0, &c->hva_base);
-            if (mem_init(c->pid, c->hva_base) == 0) {
+            if (mem_init(c->pid, qmp_gpa2hva) == 0) {
                 c->readmem = mem_read;
             } else {
                 c->readmem = qmp_readmem;

--- a/client.h
+++ b/client.h
@@ -28,7 +28,6 @@ typedef enum {
 typedef struct {
     guest_access_t ty;
     pid_t pid;
-    uint64_t hva_base;
     int (*get_registers)(uint64_t*, uint64_t*, uint64_t*);
     int (*readmem)(uint64_t, void*, size_t);
 } guest_client_t;

--- a/mem.h
+++ b/mem.h
@@ -15,12 +15,15 @@
 #ifndef __MEM_H__
 #define __MEM_H__
 
+#include <stdint.h>
+#include <sys/types.h>
+
 typedef struct {
     int mem_fd;
-    uint64_t hva_base;
+    int (*gpa2hva)(uint64_t gpa, uint64_t *hva);
 } proc_mem_t;
 
-int mem_init(pid_t pid, uint64_t hva_base);
+int mem_init(pid_t pid, int (*gpa2hva)(uint64_t, uint64_t*));
 int mem_uninit();
 int mem_read(uint64_t addr, void *buffer, size_t size);
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -120,7 +120,7 @@ def qemu_run(vmlinux_path):
         '-nographic',
         '-no-reboot',
         '-append', 'console=ttyS0',
-        '-m', '1G',
+        '-m', '4G',
         '-smp', '1',
         '-qmp', 'unix:/tmp/qmp.sock,server,nowait',
         '-monitor', 'unix:/tmp/mon.sock,server,nowait'


### PR DESCRIPTION
When guest memory exceeds 4GB, QEMU does not allocate a contiguous address space for the VM's physical memory. The previous approach of using a fixed HVA base address (hva_base) to calculate memory offsets fails in this scenario, causing memory read operations to access incorrect addresses.

Replace the fixed offset calculation with a dynamic GPA-to-HVA translation by passing the gpa2hva function pointer to mem_init() instead of a static base address. This allows mem_read() to properly resolve the correct HVA for each memory access regardless of the guest's memory layout.

The client structure is also simplified by removing the hva_base field, which is no longer needed.