### PR TITLE
Add AArch64 support(wip)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,17 @@ ifeq ($(STATIC), y)
 	LDFLAGS += -static
 endif
 
+ARCH ?= $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	ARCH_SRC := arch/x86_64.c
+else ifeq ($(ARCH),aarch64)
+	ARCH_SRC := arch/aarch64.c
+else
+	$(error unsupported architecture: $(ARCH))
+endif
+
 SRC = main.c \
+	  $(ARCH_SRC) \
 	  log.c \
 	  kernel.c \
 	  version.c \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Two Connection Methods**: It supports two different interfaces for log retrieval:
   - **libvirt Interface**: Fetch logs from VMs managed through the libvirt virtualization API.
   - **QMP Socket**: Connect directly to the QEMU monitor protocol (QMP) socket for communication.
-- **x86_64 Linux VM Support**: This tool currently supports only x86_64 Linux virtual machines.
+- **x86_64 and AArch64 Linux VM Support**: Supports both x86_64 and AArch64 Linux virtual machines.
 - **System.map Symbol Table**: `kvm-dmesg` requires access to the guest VM's `System.map` symbol table to map kernel log addresses to human-readable symbols.
 
 ## Compilation
@@ -67,7 +67,7 @@ $ ./kvm-dmesg /tmp/qmp.sock System.map-5.15.171
 
 - Linux-based host with KVM support.
 - Libvirt or access to the QMP socket for the virtual machine.
-- The tool currently only supports x86_64 Linux guests.
+- The tool supports x86_64 and AArch64 Linux guests.
 - The guest's `System.map` file must be available for symbol resolution.
 
 ## Acknowledgments

--- a/arch.h
+++ b/arch.h
@@ -1,0 +1,16 @@
+/* arch.h
+ *
+ * Architecture abstraction layer.
+ */
+
+#ifndef __ARCH_H__
+#define __ARCH_H__
+
+#include "defs.h"
+
+int arch_init(void);
+int arch_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base);
+int arch_post_reloc(void);
+int arch_kvtop(ulong kvaddr, physaddr_t *paddr);
+
+#endif

--- a/arch/aarch64.c
+++ b/arch/aarch64.c
@@ -1,0 +1,168 @@
+/* arch/aarch64.c
+ *
+ * AArch64 architecture support.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aarch64.h"
+#include "../arch.h"
+#include "../defs.h"
+#include "../log.h"
+#include "../mem.h"
+#include "../xutil.h"
+
+static struct machine_specific aarch64_machine_specific;
+
+void aarch64_init(void)
+{
+    machdep->machspec = &aarch64_machine_specific;
+
+    machdep->pagesize = ARM64_PAGE_SIZE;
+    machdep->pageoffset = machdep->pagesize - 1;
+    machdep->pagemask = ~((ulonglong)machdep->pageoffset);
+
+    machdep->pgd = malloc(PAGESIZE());
+    machdep->pud = malloc(PAGESIZE());
+    machdep->pmd = malloc(PAGESIZE());
+    machdep->ptbl = malloc(PAGESIZE());
+
+    machdep->machspec->page_offset = ARM64_PAGE_OFFSET;
+    machdep->machspec->pgdir_shift = 0;
+    machdep->machspec->ptrs_per_pgd = 0;
+    machdep->machspec->physical_mask_shift = ARM64_VA_BITS;
+}
+
+void aarch64_post_reloc(void)
+{
+    /*
+     * AArch64 uses kimage_voffset from vmcoreinfo for address translation.
+     * Nothing else to adjust here.
+     */
+}
+
+int aarch64_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base)
+{
+    char vmcoreinfo_buf_local[4096];
+    ulong kimage_voffset_value = 0;
+    ulong kernel_offset = 0;
+    ulong text_link;
+    char *p;
+
+    /*
+     * QEMU does not expose TTBR1_EL1 through the human monitor command on
+     * AArch64, so we cannot walk the page tables.  Instead scan guest RAM for
+     * the vmcoreinfo note, which contains everything we need:
+     *   NUMBER(kimage_voffset) : runtime_vaddr - phys_addr
+     *   KERNELOFFSET           : KASLR randomization offset
+     */
+    if (mem_scan_vmcoreinfo(vmcoreinfo_buf_local, sizeof(vmcoreinfo_buf_local)) < 0) {
+        pr_err("Failed to scan vmcoreinfo from guest RAM");
+        return -1;
+    }
+
+    p = strstr(vmcoreinfo_buf_local, "NUMBER(kimage_voffset)=");
+    if (p)
+        sscanf(p + strlen("NUMBER(kimage_voffset)="), "%lx", &kimage_voffset_value);
+
+    p = strstr(vmcoreinfo_buf_local, "KERNELOFFSET=");
+    if (p)
+        sscanf(p + strlen("KERNELOFFSET="), "%lx", &kernel_offset);
+
+    if (!kimage_voffset_value) {
+        pr_err("vmcoreinfo does not contain kimage_voffset");
+        return -1;
+    }
+
+    /*
+     * Keep the scanned vmcoreinfo so vmcoreinfo_init() does not have to read
+     * vmcoreinfo_data, whose pointer may live in the vmalloc region and
+     * therefore cannot be translated without a page table walk.
+     */
+    if (!vmcoreinfo_buf) {
+        vmcoreinfo_size = sizeof(vmcoreinfo_buf_local) - 1;
+        vmcoreinfo_buf = xmalloc(vmcoreinfo_size + 1);
+        memcpy(vmcoreinfo_buf, vmcoreinfo_buf_local, vmcoreinfo_size);
+        vmcoreinfo_buf[vmcoreinfo_size] = '\0';
+    }
+
+    if (kernel_symbol_exists("_text")) {
+        text_link = symbol_value("_text");
+    } else if (kernel_symbol_exists("_stext")) {
+        text_link = symbol_value("_stext");
+    } else {
+        pr_err("_text/_stext symbol not found");
+        return -1;
+    }
+
+    machdep->machspec->kimage_voffset = kimage_voffset_value;
+    machdep->machspec->kaslr_offset = kernel_offset;
+
+    /*
+     * Runtime KIMAGE_VADDR is the link-time _text plus the KASLR offset.
+     * Round it down to a 2 MB boundary so all kernel image addresses are
+     * handled by the kimage_voffset path.
+     */
+    machdep->machspec->kimage_vaddr =
+        (text_link + kernel_offset) & ~((1UL << 21) - 1);
+
+    *kaslr_offset = kernel_offset;
+    *phys_base = machdep->machspec->kimage_vaddr - kimage_voffset_value;
+
+    if (KDEBUG(1)) {
+        pr_debug("ARM64 kimage_voffset: 0x%lx", kimage_voffset_value);
+        pr_debug("ARM64 KERNELOFFSET: 0x%lx", kernel_offset);
+        pr_debug("ARM64 kimage_vaddr: 0x%lx", machdep->machspec->kimage_vaddr);
+        pr_debug("ARM64 phys_base: 0x%lx", *phys_base);
+    }
+
+    return 0;
+}
+
+int aarch64_kvtop(ulong kvaddr, physaddr_t *paddr)
+{
+    if (machdep->machspec->kimage_vaddr &&
+        kvaddr >= machdep->machspec->kimage_vaddr) {
+        *paddr = kvaddr - machdep->machspec->kimage_voffset;
+    } else if (kvaddr >= ARM64_PAGE_OFFSET) {
+        *paddr = kvaddr - PAGE_OFFSET;
+    } else if (machdep->machspec->kimage_voffset) {
+        /* vmalloc / modules / etc */
+        *paddr = kvaddr - machdep->machspec->kimage_voffset;
+    } else {
+        pr_err("Invalid ARM64 kernel address: 0x%lx", kvaddr);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Public architecture interface */
+
+int arch_init(void)
+{
+    aarch64_init();
+    return 0;
+}
+
+int arch_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base)
+{
+    if (aarch64_calc_kaslr_offset(kaslr_offset, phys_base) < 0) {
+        pr_err("Failed to calculate KASLR offset");
+        return -1;
+    }
+    return 0;
+}
+
+int arch_post_reloc(void)
+{
+    aarch64_post_reloc();
+    return 0;
+}
+
+int arch_kvtop(ulong kvaddr, physaddr_t *paddr)
+{
+    return aarch64_kvtop(kvaddr, paddr);
+}

--- a/arch/aarch64.h
+++ b/arch/aarch64.h
@@ -1,0 +1,21 @@
+/* arch/aarch64.h
+ *
+ * AArch64 specific declarations.
+ */
+
+#ifndef __ARCH_AARCH64_H__
+#define __ARCH_AARCH64_H__
+
+#include "../defs.h"
+
+#define ARM64_VA_BITS          48
+#define ARM64_PAGE_SHIFT       12
+#define ARM64_PAGE_SIZE        (1UL << ARM64_PAGE_SHIFT)
+#define ARM64_PAGE_OFFSET      0xffff800000000000UL
+
+void aarch64_init(void);
+void aarch64_post_reloc(void);
+int aarch64_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base);
+int aarch64_kvtop(ulong kvaddr, physaddr_t *paddr);
+
+#endif

--- a/arch/x86_64.c
+++ b/arch/x86_64.c
@@ -1,0 +1,210 @@
+/* arch/x86_64.c
+ *
+ * x86_64 architecture support.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "x86_64.h"
+#include "../arch.h"
+#include "../client.h"
+#include "../defs.h"
+#include "../log.h"
+#include "../mem.h"
+#include "../xutil.h"
+
+static struct machine_specific x86_64_machine_specific;
+
+static ulong *x86_64_kpgd_offset(ulong kvaddr)
+{
+    ulong *pgd;
+    pgd = ((ulong *)machdep->pgd) + pgd_index(kvaddr);
+    return pgd;
+}
+
+static ulong x86_64_pud_offset(ulong pgd_pte, ulong vaddr)
+{
+    ulong *pud;
+    ulong pud_paddr;
+    ulong pud_pte;
+
+    pud_paddr = pgd_pte & PHYSICAL_PAGE_MASK;
+
+    FILL_PUD(pud_paddr, PAGESIZE());
+    pud = ((ulong *)pud_paddr) + pud_index(vaddr);
+    pud_pte = ULONG(machdep->pud + PAGEOFFSET(pud));
+
+    return pud_pte;
+}
+
+static ulong x86_64_pmd_offset(ulong pud_pte, ulong vaddr)
+{
+    ulong *pmd;
+    ulong pmd_paddr;
+    ulong pmd_pte;
+
+    pmd_paddr = pud_pte & PHYSICAL_PAGE_MASK;
+
+    FILL_PMD(pmd_paddr, PAGESIZE());
+
+    pmd = ((ulong *)pmd_paddr) + pmd_index(vaddr);
+    pmd_pte = ULONG(machdep->pmd + PAGEOFFSET(pmd));
+    return pmd_pte;
+}
+
+static ulong x86_64_pte_offset(ulong pmd_pte, ulong vaddr)
+{
+    ulong *ptep;
+    ulong pte_paddr;
+    ulong pte;
+
+    pte_paddr = pmd_pte & PHYSICAL_PAGE_MASK;
+
+    FILL_PTBL(pte_paddr, PAGESIZE());
+    ptep = ((ulong *)pte_paddr) + pte_index(vaddr);
+    pte = ULONG(machdep->ptbl + PAGEOFFSET(ptep));
+
+    return pte;
+}
+
+int x86_64_kvtop(ulong kvaddr, physaddr_t *paddr)
+{
+    ulong *pgd;
+    ulong pud_pte;
+    ulong pmd_pte;
+    ulong pte;
+
+    pgd = x86_64_kpgd_offset(kvaddr);
+    pud_pte = x86_64_pud_offset(*pgd, kvaddr);
+    pmd_pte = x86_64_pmd_offset(pud_pte, kvaddr);
+    pte = x86_64_pte_offset(pmd_pte, kvaddr);
+    *paddr = (PAGEBASE(pte) & PHYSICAL_PAGE_MASK) + PAGEOFFSET(kvaddr);
+
+    return 0;
+}
+
+static ulong get_vec0_addr(ulong idtr)
+{
+    struct gate_struct64 {
+        uint16_t offset_low;
+        uint16_t segment;
+        uint32_t ist : 3, zero0 : 5, type : 5, dpl : 2, p : 1;
+        uint16_t offset_middle;
+        uint32_t offset_high;
+        uint32_t zero1;
+    } __attribute__((packed)) gate;
+
+    readmem(idtr, PHYSADDR, &gate, sizeof(gate));
+
+    return ((ulong)gate.offset_high << 32)
+        + ((ulong)gate.offset_middle << 16)
+        + gate.offset_low;
+}
+
+#define PTI_USER_PGTABLE_BIT    PAGE_SHIFT
+#define PTI_USER_PGTABLE_MASK   (1 << PTI_USER_PGTABLE_BIT)
+#define CR3_PCID_MASK           0xFFFull
+
+int x86_64_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base)
+{
+    uint64_t cr3 = 0, idtr = 0, pgd = 0, idtr_paddr;
+    ulong divide_error_vmcore;
+
+    get_cr3_idtr(&cr3, &idtr);
+
+    pgd = cr3 & ~(CR3_PCID_MASK|PTI_USER_PGTABLE_MASK);
+
+    vt->kernel_pgd[0] = pgd;
+    machdep->last_pgd_read = vt->kernel_pgd[0];
+    machdep->machspec->physical_mask_shift = __PHYSICAL_MASK_SHIFT_2_6;
+    machdep->machspec->pgdir_shift = PGDIR_SHIFT;
+    machdep->machspec->ptrs_per_pgd = PTRS_PER_PGD;
+
+    readmem(pgd, PHYSADDR, machdep->pgd, PAGESIZE());
+    x86_64_kvtop(idtr, &idtr_paddr);
+
+    divide_error_vmcore = get_vec0_addr(idtr_paddr);
+    *kaslr_offset = divide_error_vmcore - st->divide_error_vmlinux;
+    *phys_base = idtr_paddr -
+        (st->idt_table_vmlinux + *kaslr_offset - __START_KERNEL_map);
+
+    if (KDEBUG(1)) {
+        pr_debug("kaslr_offset: idtr=%lx", idtr);
+        pr_debug("kaslr_offset: pgd=%lx", pgd);
+        pr_debug("kaslr_offset: idtr(phys)=%lx", idtr_paddr);
+        pr_debug("kaslr_offset: divide_error(vmcore): %lx", divide_error_vmcore);
+        pr_debug("kaslr_offset: kaslr_offset=%lx", *kaslr_offset);
+        pr_debug("kaslr_offset: phys_base   =%lx", *phys_base);
+    }
+
+    return 0;
+}
+
+void x86_64_init(void)
+{
+    machdep->machspec = &x86_64_machine_specific;
+
+    machdep->pagesize = 4096;
+    machdep->pageoffset = machdep->pagesize - 1;
+    machdep->pagemask = ~((ulonglong)machdep->pageoffset);
+
+    machdep->pgd = malloc(PAGESIZE());
+    machdep->pud = malloc(PAGESIZE());
+    machdep->pmd = malloc(PAGESIZE());
+    machdep->ptbl = malloc(PAGESIZE());
+
+    machdep->machspec->page_offset = PAGE_OFFSET_2_6_27;
+}
+
+void x86_64_post_reloc(void)
+{
+    if (kernel_symbol_exists("page_offset_base")) {
+        ulong page_offset_base = 0;
+        get_symbol_data("page_offset_base", sizeof(ulong), &page_offset_base);
+        if (page_offset_base)
+            machdep->machspec->page_offset = page_offset_base;
+    }
+}
+
+/* Public architecture interface */
+
+int arch_init(void)
+{
+    x86_64_init();
+    return 0;
+}
+
+int arch_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base)
+{
+    if (x86_64_calc_kaslr_offset(kaslr_offset, phys_base) < 0) {
+        pr_err("Failed to calculate KASLR offset");
+        return -1;
+    }
+    return 0;
+}
+
+int arch_post_reloc(void)
+{
+    x86_64_post_reloc();
+    return 0;
+}
+
+int arch_kvtop(ulong kvaddr, physaddr_t *paddr)
+{
+    /*
+     * x86_64 kernel virtual addresses are either in the kernel image region
+     * (__START_KERNEL_map, translated with phys_base) or in the direct linear
+     * map (translated with PAGE_OFFSET).  This matches the behaviour of the
+     * original kvm-dmesg and works for kernels that map the log buffer with
+     * huge pages, which the page table walker does not handle.
+     */
+    if (kvaddr >= __START_KERNEL_map) {
+        *paddr = (kvaddr - __START_KERNEL_map) + machdep->machspec->phys_base;
+    } else {
+        *paddr = kvaddr - PAGE_OFFSET;
+    }
+    return 0;
+}

--- a/arch/x86_64.h
+++ b/arch/x86_64.h
@@ -1,0 +1,16 @@
+/* arch/x86_64.h
+ *
+ * x86_64 specific declarations.
+ */
+
+#ifndef __ARCH_X86_64_H__
+#define __ARCH_X86_64_H__
+
+#include "../defs.h"
+
+void x86_64_init(void);
+void x86_64_post_reloc(void);
+int x86_64_calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base);
+int x86_64_kvtop(ulong kvaddr, physaddr_t *paddr);
+
+#endif

--- a/client.c
+++ b/client.c
@@ -2,6 +2,7 @@
 #include "xutil.h"
 #include "mem.h"
 #include "client.h"
+#include "arch.h"
 
 guest_client_t *guest_client = NULL;
 
@@ -18,11 +19,8 @@ int readmem(uint64_t addr, int memtype, void *buffer, long size)
 
     switch (memtype) {
         case KVADDR:
-            if (addr >= __START_KERNEL_map) {
-                paddr = ((addr) - (ulong)__START_KERNEL_map + machdep->machspec->phys_base);
-            } else {
-                paddr = ((addr) - PAGE_OFFSET);
-            }
+            if (arch_kvtop(addr, &paddr) < 0)
+                return -1;
             break;
         case PHYSADDR:
             paddr = addr;
@@ -39,6 +37,7 @@ int guest_client_new(char *ac, guest_access_t ty)
 
     guest_client_t *c = xcalloc(1, sizeof(guest_client_t));
     c->ty = ty;
+
     switch(c->ty) {
         case GUEST_NAME:
             if (libvirt_client_init(ac))

--- a/client.c
+++ b/client.c
@@ -3,6 +3,7 @@
 #include "mem.h"
 #include "client.h"
 #include "arch.h"
+#include "log.h"
 
 guest_client_t *guest_client = NULL;
 
@@ -48,7 +49,11 @@ int guest_client_new(char *ac, guest_access_t ty)
             } else {
                 c->readmem = libvirt_readmem;
             }
+#ifdef __aarch64__
+            c->get_registers = NULL;
+#else
             c->get_registers = libvirt_get_registers;
+#endif
             break;
         case GUEST_MEMORY:
             if (file_client_init(ac))
@@ -65,7 +70,11 @@ int guest_client_new(char *ac, guest_access_t ty)
             } else {
                 c->readmem = qmp_readmem;
             }
+#ifdef __aarch64__
+            c->get_registers = NULL;
+#else
             c->get_registers = qmp_get_registers;
+#endif
             break;
     }
     guest_client = c;

--- a/client.h
+++ b/client.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 typedef enum {
     GUEST_NAME,
@@ -56,5 +57,7 @@ int file_client_init(char *sock_path);
 int file_client_uninit();
 int file_get_registers(uint64_t *idtr, uint64_t *cr3, uint64_t *cr4);
 int file_readmem(uint64_t addr, void *buffer, size_t size);
+
+extern guest_client_t *guest_client;
 
 #endif

--- a/defs.h
+++ b/defs.h
@@ -191,6 +191,11 @@ struct machine_specific {
     ulong pgdir_shift;
     ulong ptrs_per_pgd;
     ulong physical_mask_shift;
+
+    /* AArch64 specific */
+    ulong kimage_voffset;   /* kernel virtual address - physical address */
+    ulong kimage_vaddr;     /* runtime KIMAGE_VADDR (start of kernel image) */
+    ulong kaslr_offset;     /* KASLR randomization offset */
 };
 
 #define PAGE_OFFSET     (machdep->machspec->page_offset)
@@ -241,6 +246,8 @@ extern struct offset_table offset_table;
 extern struct size_table size_table;
 extern struct vm_table vm_table, *vt;
 extern struct symbol_table_data symbol_table_data, *st;
+extern char *vmcoreinfo_buf;
+extern size_t vmcoreinfo_size;
 
 
 /*

--- a/docs/crash-utility-comparison.md
+++ b/docs/crash-utility-comparison.md
@@ -1,0 +1,203 @@
+# crash-utility 与 kvm-dmesg 实现对比分析
+
+本文把 `crash-utility`（内核崩溃分析工具）的日志打印实现拉出来，与 `kvm-dmesg` 做对比，看看同样是从“裸内存”里把 `dmesg` 捞出来，两者在思路上有什么异同。
+
+分析基于 crash-utility 源码（`crash-utility/crash`）中的以下文件：
+
+- `kernel.c`：`log` / `dmesg` 命令入口，处理旧格式日志
+- `printk.c`：处理新的 `printk_ringbuffer`（prb）
+- `symbols.c`：符号表和 `vmcoreinfo` 解析
+- `x86_64.c`：x86_64 架构初始化、地址翻译、KASLR 处理
+- `arm64.c`：AArch64 架构初始化、地址翻译、KASLR 处理
+- `memory.c` / `diskdump.c` / `dev.c`：内存读取后端
+
+## 1. crash-utility 是什么
+
+`crash-utility` 是一个通用的内核崩溃分析器，支持：
+
+- kdump 生成的 `vmcore`
+- `/proc/kcore`（live 系统内存）
+- `/dev/crash`（live 系统，内核暴露的 raw 内存接口）
+- `diskdump`、`sadump`、`kvmdump`、`vmss`、`xendump` 等多种 dump 格式
+- 本地或远程内存源
+
+它不仅能打印 `dmesg`，还能看任务列表、调用栈、内存、文件系统、网络等。打印 `dmesg` 只是其中一个命令（`log`）。
+
+## 2. crash-utility 打印 dmesg 的流程
+
+命令入口在 `kernel.c` 的 `cmd_log()`，它会依次尝试三种内核日志格式：
+
+```c
+if (kernel_symbol_exists("prb"))
+    dump_lockless_record_log(msg_flags);          // printk.c
+else if (kernel_symbol_exists("log_first_idx") &&
+         kernel_symbol_exists("log_next_idx"))
+    dump_variable_length_record_log(msg_flags);   // kernel.c
+else
+    dump_raw_log_buf(msg_flags);                  // kernel.c
+```
+
+这与 `kvm-dmesg` 的判断顺序完全一致。
+
+### 2.1 prb（printk_ringbuffer）
+
+`printk.c` 里的 `dump_lockless_record_log()` 与 `kvm-dmesg` 思路相同：
+
+1. 读 `prb` 全局变量。
+2. 从 `prb.desc_ring` 拿到描述符数组、info 数组、tail_id/head_id。
+3. 从 `prb.text_data_ring` 拿到文本数据环。
+4. 从 tail 到 head 遍历描述符，检查 `state_var` 的高 2 位，只输出 `committed` / `finalized` 记录。
+5. 根据 `text_blk_lpos.begin/next` 取文本，跳过开头的 `desc_id`，按 `printk_info.text_len` 输出。
+
+crash-utility 更完善的地方：
+
+- 支持 `SHOW_LOG_CALLER`、`SHOW_LOG_LEVEL`、`SHOW_LOG_CTIME`、`SHOW_LOG_DICT` 等多种显示选项。
+- 处理 Rust 调用栈的 demangle。
+- 对文本换行、截断等边界情况处理得更细致。
+
+### 2.2 variable-length record（struct log）
+
+`kernel.c` 里的 `dump_variable_length_record_log()` 与 `kvm-dmesg` 基本相同：
+
+- 读 `log_first_idx`、`log_next_idx`、`log_buf_len`、`log_buf`。
+- 用 `log_from_idx()` / `log_next()` 在环形缓冲区上遍历。
+- `dump_log_entry()` 解析 `struct log` 的 `ts_nsec`、`text_len` 等字段。
+
+### 2.3 最老的 raw log_buf
+
+如果前两种符号都不存在，crash-utility 会直接读 `log_buf` 数组，按字符环形缓冲区处理。`kvm-dmesg` 也有同样的兜底逻辑。
+
+## 3. 符号解析与 vmcoreinfo
+
+crash-utility 的符号表在 `symbols.c` 中维护。它的输入通常是：
+
+- `vmlinux`（可选，带 debuginfo 最好）
+- `System.map`
+- dump 文件里的 ELF notes，尤其是 `VMCOREINFO`
+
+### 3.1 为什么依赖 vmcoreinfo
+
+crash-utility 大量读取 dump 文件中的 `VMCOREINFO` note。这个 note 里保存了崩溃时内核自动导出的关键常量和符号值，例如：
+
+```text
+SYMBOL(log_buf)=ffffffff8a123456
+SYMBOL(log_buf_len)=ffffffff8a123460
+SYMBOL(log_first_idx)=ffffffff8a123464
+SYMBOL(log_next_idx)=ffffffff8a123468
+SYMBOL(prb)=ffffffff8a123470
+NUMBER(KERNEL_IMAGE_SIZE)=0x2000000
+NUMBER(phys_base)=0x1000000
+NUMBER(page_offset_base)=0xffff888000000000
+NUMBER(VA_BITS)=48
+NUMBER(kimage_voffset)=0xffff000008000000
+OSRELEASE=6.6.0
+SIZE(printk_info)=32
+OFFSET(printk_info.ts_nsec)=0
+OFFSET(printk_info.text_len)=16
+```
+
+`symbols.c` 和 `kernel.c` 中有专门的 `read_vmcoreinfo()` 接口，把这些字符串解析成数值。
+
+### 3.2 与 kvm-dmesg 的对比
+
+| | crash-utility | kvm-dmesg |
+|---|---|---|
+| 符号来源 | `vmlinux` + `System.map` + `vmcoreinfo` | 仅 `System.map` |
+| 结构体布局 | `vmcoreinfo` 中的 `SIZE(...)` / `OFFSET(...)`，或 `vmlinux` debuginfo | `vmcoreinfo` 中的 `SIZE(...)` / `OFFSET(...)` |
+| `log_buf` 等符号地址 | 优先用 `vmcoreinfo` 里的 `SYMBOL(...)` | 从 `System.map` 读链接地址，再用 KASLR 偏移修正 |
+
+也就是说，crash-utility 把“运行时地址”这件事大量外包给了 `vmcoreinfo`，而 `kvm-dmesg` 因为拿不到完整的 `vmcoreinfo` 符号值，只能自己从 `System.map` 和寄存器/vmcoreinfo 推。
+
+## 4. KASLR 与地址翻译
+
+### 4.1 x86_64
+
+在 `x86_64.c` 的 `x86_64_init()` 中：
+
+1. **读取 KASLR 偏移**
+   直接从 `vmcoreinfo` 读 `relocate`：
+   ```c
+   if ((string = pc->read_vmcoreinfo("relocate"))) {
+       kt->relocate = htol(string, QUIET, NULL);
+       kt->flags |= RELOC_SET;
+       kt->flags2 |= KASLR;
+   }
+   ```
+   如果 `vmcoreinfo` 里有这个字段，后续符号地址直接减去 `relocate` 即可。
+
+2. **计算 phys_base**
+   在 `x86_64_calc_phys_base()` 中，依次尝试：
+   - `vmcoreinfo` 中的 `NUMBER(phys_base)`
+   - 读取符号 `phys_base` 的值
+   - 用 `_text` / `_stext` 等符号和 `__START_KERNEL_map` 推导
+
+3. **地址翻译**
+   `x86_64_kvtop()` 实现完整的页表 walk，支持：
+   - 4 级 / 5 级页表
+   - 2 MB / 1 GB huge page
+   - Xen、KVM、EFI、SME 等特殊场景
+   - `CONFIG_RANDOMIZE_MEMORY` 下的 `page_offset_base` 动态线性区
+
+   简单地址也通过 `__START_KERNEL_map + phys_base` / `PAGE_OFFSET` 快速翻译，但复杂地址（vmalloc、modules、vmemmap）会走页表。
+
+### 4.2 AArch64
+
+在 `arm64.c` 的 `arm64_init()` 中：
+
+1. **读取 kimage_voffset**
+   优先从 `vmcoreinfo` 读 `NUMBER(kimage_voffset)`。
+   如果是 live 系统，还可以通过 `/dev/crash` 的 `DEV_CRASH_ARCH_DATA` ioctl，或 `/proc/kallsyms` 获取。
+
+2. **计算 PHYS_OFFSET 与 phys_base**
+   从 `vmcoreinfo` 读 `NUMBER(PHYS_OFFSET)`，或用 `memstart_addr` 符号减去 `kimage_voffset`。
+
+3. **地址翻译**
+   `arm64_kvtop()`：
+   - 线性映射区、内核映像区用 `kimage_voffset` / `PAGE_OFFSET` 简单翻译。
+   - `vmalloc` 区域走页表 walk（`arm64_init_kernel_pgd()` 从 `init_mm.pgd` 或 `swapper_pg_dir` 拿到内核页表根）。
+
+### 4.3 与 kvm-dmesg 的对比
+
+| | crash-utility | kvm-dmesg |
+|---|---|---|
+| KASLR 来源 | `vmcoreinfo("relocate")` / `KERNELOFFSET` / `kimage_voffset` | x86_64：从 CR3/IDTR 推导；AArch64：扫描 vmcoreinfo |
+| phys_base 来源 | `vmcoreinfo`、符号、`__START_KERNEL_map` 推导 | x86_64：IDTR 推导；AArch64：`kimage_vaddr - kimage_voffset` |
+| 页表 walk | 完整支持，含 huge page、5-level、vmalloc | x86_64：只 walk IDTR 计算 KASLR；实际读内存用简单偏移；AArch64：不 walk |
+| 架构覆盖 | x86、x86_64、arm64、ppc、ia64、s390 等 | 仅 x86_64 和 AArch64 |
+| 鲁棒性 | 很高，能处理大量 corner case | 够用但有限（例如不处理 huge page） |
+
+## 5. 内存读取后端
+
+crash-utility 的 `readmem(addr, KVADDR, ...)` 隐藏了底层差异：
+
+- **vmcore / diskdump**：把 dump 文件映射到内存，按内存段表（`pt_load` 或 diskdump 段表）找到对应物理页。
+- **/proc/kcore**：读取 `/proc/kcore` 的 ELF 段。
+- **/dev/crash**：直接 ioctl/read。
+- **live qemu**：可通过 `kvmdump.c` 读取 QEMU 内存。
+
+`kvm-dmesg` 的内存后端则简单得多：
+
+- 优先 `/proc/<pid>/mem` + `gpa2hva`。
+- 回退 QMP `xp` 命令或 libvirt 内存接口。
+- 只面向运行中的 QEMU/KVM 虚拟机。
+
+## 6. 代码组织与依赖
+
+| | crash-utility | kvm-dmesg |
+|---|---|---|
+| 代码规模 | 约 20 万行 C | 约 2000 行 C |
+| 依赖 | 需要 `vmlinux`/`System.map`/dump 文件；编译依赖 ncurses、lzo/snappy 等压缩库、gdb 等 | 只需要 `System.map` 和 QMP/libvirt；编译几乎无额外依赖 |
+| 运行方式 | 交互式命令行工具 | 单次命令行工具 |
+| 使用场景 | 崩溃分析、离线调查 | 运行中虚拟机快速抓 dmesg |
+
+## 7. 总结
+
+虽然 `crash-utility` 和 `kvm-dmesg` 最终都殊途同归——找到 `log_buf` / `prb`，按格式解码——但两者的设计哲学明显不同：
+
+- **crash-utility**：
+  > “我面对的是各种各样的 dump/live 源，必须尽可能通用和鲁棒。所以我依赖 `vmcoreinfo` 和完整的页表 walk，尽量覆盖所有内核版本和架构。”
+
+- **kvm-dmesg**：
+  > “我只做一件事：从运行中的 QEMU/KVM 虚拟机里抓 dmesg。所以我用 System.map + 寄存器/vmcoreinfo 快速算出 KASLR，用简单偏移读内存，保持代码最小化。”
+
+对于 QEMU/KVM 运行中 guest 的快速排障，`kvm-dmesg` 更轻量；对于内核崩溃后的深度分析，`crash-utility` 是不可替代的工具。

--- a/docs/kernel-gdb-dmesg-analysis.md
+++ b/docs/kernel-gdb-dmesg-analysis.md
@@ -1,0 +1,191 @@
+# Linux 内核 GDB 脚本 `lx-dmesg` 的实现分析
+
+Linux 内核源码树里自带了一套 GDB helper 脚本，放在 `scripts/gdb/linux/` 目录下。其中 `dmesg.py` 提供了 `lx-dmesg` 命令，作用与 `kvm-dmesg` 类似：把目标内核的 `dmesg` 打印出来。本文档分析它是如何实现的，并与 `kvm-dmesg` 的做法做对比。
+
+## 1. 运行环境与前提
+
+`lx-dmesg` 不是独立程序，而是运行在 GDB 内部的 Python 脚本。要使用它，必须满足以下条件：
+
+1. **有一份带调试信息的 `vmlinux`**。
+   GDB 需要从中读取符号地址、结构体大小和成员偏移。
+2. **GDB 已经连接到能访问内核内存的 target**。
+   常见场景：
+   - QEMU 的 gdbstub（`qemu -s -S`）
+   - KGDB（串口/以太网调试）
+   - `gdb` 打开 kdump/vmcore 崩溃转储文件
+
+在这些场景下，GDB 自己就已经知道内核符号、结构体布局，并且 target backend 会负责把内核虚拟地址翻译成实际可读的内存。所以 `dmesg.py` 完全不需要自己处理 KASLR、页表 walk、物理地址翻译这些事情。
+
+## 2. 获取 `prb` 符号地址
+
+现代内核使用 `printk_ringbuffer`（简称 `prb`）作为日志缓冲区。脚本首先要找到 `prb` 这个全局变量在内存里的地址：
+
+```python
+prb_addr = int(str(gdb.parse_and_eval("(void *)'printk.c'::prb")).split()[0], 16)
+```
+
+这里用了 GDB 的表达式解析：
+
+- `'printk.c'::prb` 表示取 `printk.c` 源文件作用域里的 `prb` 符号。
+- `(void *)` 把它转换成指针。
+- 结果字符串形如 `"0xffff888123456789"`，split 后取第一个 token 转成整数。
+
+**与 kvm-dmesg 的对比**：
+
+| | `lx-dmesg` | `kvm-dmesg` |
+|---|---|---|
+| 符号地址来源 | GDB 解析 `vmlinux` 调试信息 | 解析 `System.map` 文本 |
+| 是否需目标连接 | 是，GDB 已 attach 到 target | 不需要，通过 QMP/libvirt/`/proc/<pid>/mem` 直接读 |
+| KASLR 处理 | GDB / target 已处理 | 自己从 CR3/IDTR 或 vmcoreinfo 计算 |
+| 页表 walk | GDB / target 已处理 | x86_64 自己 walk；AArch64 不 walk |
+
+## 3. 读取结构体布局信息
+
+`dmesg.py` 不需要像 `kvm-dmesg` 那样去 `vmcoreinfo` 里查结构体大小和偏移。它直接用 GDB 的 type 查询接口：
+
+```python
+printk_info_type = utils.CachedType("struct printk_info")
+prb_desc_type = utils.CachedType("struct prb_desc")
+prb_desc_ring_type = utils.CachedType("struct prb_desc_ring")
+prb_data_ring_type = utils.CachedType("struct prb_data_ring")
+printfk_ringbuffer_type = utils.CachedType("struct printk_ringbuffer")
+```
+
+然后通过 `type['field'].bitpos // 8` 得到成员偏移，例如：
+
+```python
+off = printk_ringbuffer_type.get_type()['desc_ring'].bitpos // 8
+```
+
+**与 kvm-dmesg 的对比**：
+
+- `kvm-dmesg` 为了兼容没有 DWARF 信息的运行环境，只能读 `vmcoreinfo` 里的 `SIZE(...)` / `OFFSET(...)` 字符串来推断结构布局。
+- `lx-dmesg` 因为依赖 `vmlinux`，所以能直接拿到精确的类型信息，代码更简洁，也不需要处理 `vmcoreinfo_data` 指针的地址翻译。
+
+## 4. 读取内存
+
+脚本通过 `gdb.inferiors()[0].read_memory(addr, size)` 读取目标内存：
+
+```python
+inf = gdb.inferiors()[0]
+prb = utils.read_memoryview(inf, prb_addr, sz).tobytes()
+```
+
+`utils.read_memoryview` 是对 `read_memory` 的薄包装，主要是为了兼容 Python 2/3 的 buffer 类型差异。
+
+因为 target backend（QEMU gdbstub / KGDB / vmcore）已经能处理内核虚拟地址，脚本只需要传虚拟地址即可。
+
+**与 kvm-dmesg 的对比**：
+
+| | `lx-dmesg` | `kvm-dmesg` |
+|---|---|---|
+| 读内存接口 | `inferior.read_memory(kvaddr)` | `/proc/<pid>/mem` 或 QMP `xp` 或 libvirt |
+| 地址类型 | 内核虚拟地址 | guest 物理地址 |
+| 地址翻译 | target 负责 | 自己实现 `arch_kvtop()` |
+
+## 5. 解析 `printk_ringbuffer`
+
+拿到 `prb` 的原始字节后，解析步骤与 `kvm-dmesg` 基本一致：
+
+1. 读 `prb` 本身。
+2. 从 `prb.desc_ring` 拿到描述符环的地址、大小、个数。
+3. 从 `prb.text_data_ring` 拿到文本数据环的地址、大小。
+4. 读 `desc_ring.tail_id` 和 `desc_ring.head_id`。
+5. 从 `tail_id` 遍历到 `head_id`：
+   - 读取每个 `prb_desc`。
+   - 检查 `state_var` 的高 2 位，只输出 `committed` 或 `finalized` 的记录。
+   - 从 `text_blk_lpos.begin` / `next` 定位文本数据。
+   - 跳过文本块开头的 `desc_id`（一个 `long`）。
+   - 根据 `printk_info.text_len` 读取文本。
+   - 把 `printk_info.ts_nsec` 转换成秒并输出。
+
+关键代码片段：
+
+```python
+desc_committed = 1
+desc_finalized = 2
+desc_sv_bits = utils.get_long_type().sizeof * 8
+desc_flags_shift = desc_sv_bits - 2
+
+did = tail_id
+while True:
+    ind = did % desc_ring_count
+    desc_off = desc_sz * ind
+    info_off = info_sz * ind
+
+    desc = utils.read_memoryview(inf, desc_addr + desc_off, desc_sz).tobytes()
+
+    state = 3 & (utils.read_atomic_long(desc, sv_off) >> desc_flags_shift)
+    if state != desc_committed and state != desc_finalized:
+        if did == head_id:
+            break
+        did = (did + 1) & desc_id_mask
+        continue
+
+    begin = utils.read_ulong(desc, begin_off) % text_data_sz
+    end = utils.read_ulong(desc, next_off) % text_data_sz
+
+    info = utils.read_memoryview(inf, info_addr + info_off, info_sz).tobytes()
+
+    if begin & 1 == 1:
+        text = ""
+    else:
+        if begin > end:
+            begin = 0
+        text_start = begin + utils.get_long_type().sizeof
+        text_len = utils.read_u16(info, len_off)
+        if end - text_start < text_len:
+            text_len = end - text_start
+        text_data = utils.read_memoryview(inf, text_data_addr + text_start,
+                                          text_len).tobytes()
+        text = text_data[0:text_len].decode(encoding='utf8', errors='replace')
+
+    time_stamp = utils.read_u64(info, ts_off)
+    for line in text.splitlines():
+        msg = u"[{time:12.6f}] {line}\n".format(
+            time=time_stamp / 1000000000.0, line=line)
+        gdb.write(msg)
+
+    if did == head_id:
+        break
+    did = (did + 1) & desc_id_mask
+```
+
+## 6. 不支持旧格式
+
+当前 `dmesg.py` 只实现了对 `printk_ringbuffer`（prb）的解析，没有处理：
+
+- 最老的原始 `log_buf` 环形缓冲区。
+- `struct log` 可变长度记录格式（`log_first_idx` / `log_next_idx`）。
+
+因此它只能用于较新的内核。如果目标内核太老，`prb` 符号不存在，`gdb.parse_and_eval` 会直接报错。
+
+`kvm-dmesg` 则同时支持三种格式，按符号存在情况自动选择：
+
+1. `prb` 存在 → 解析 lockless ringbuffer。
+2. `log_first_idx` / `log_next_idx` 存在 → 解析 `struct log`。
+3. 否则 → 直接按字符数组打印 `log_buf`。
+
+## 7. 各自适用的场景
+
+| 场景 | 推荐工具 |
+|---|---|
+| 已有 `vmlinux` 调试信息，且 GDB 已连到 QEMU/KGDB/vmcore | `lx-dmesg` 更省事 |
+| 只有 `System.map`，guest 还在运行，没有 vmlinux 调试信息 | `kvm-dmesg` |
+| 需要兼容老内核（3.x / 4.x） | `kvm-dmesg` |
+| 需要脚本化、批量处理、不启动 GDB | `kvm-dmesg` |
+| AArch64 运行中 guest | `kvm-dmesg`（`lx-dmesg` 也能工作，但需 GDB 环境） |
+
+## 8. 小结
+
+`lx-dmesg` 的解决思路可以概括为：
+
+> **把地址翻译、KASLR、符号解析、结构体布局这些脏活都交给 GDB + target backend，脚本只负责按 `printk_ringbuffer` 的格式把日志解码出来。**
+
+它的优势是代码简洁、结构信息精确、不需要 `System.map`；劣势是必须依赖 GDB 调试环境和带 DWARF 的 `vmlinux`，且只支持新内核的 prb 格式。
+
+`kvm-dmesg` 则走了另一条路：
+
+> **不依赖 GDB，只通过 host 上可得的接口（QMP/libvirt/proc）和 `System.map`，自己完成 KASLR 计算、地址翻译、结构解析。**
+
+这条路更通用、更独立，但也因此代码更复杂，需要分别为 x86_64 和 AArch64 处理地址翻译，并且要从 `vmcoreinfo` 推断结构体布局。

--- a/docs/kvm-dmesg-internals.md
+++ b/docs/kvm-dmesg-internals.md
@@ -1,0 +1,247 @@
+# kvm-dmesg 实现原理：从寄存器到 dmesg
+
+本文档描述 `kvm-dmesg` 如何从一台运行中的 KVM/QEMU 虚拟机里把内核的 `dmesg` 打印出来的基本流程。阅读对象是想要了解其内部实现的人。
+
+## 1. 这个东西是干什么的
+
+`kvm-dmesg` 不进入 guest、不依赖 guest 里的任何工具，只通过 host 上能访问到的 QEMU 接口（QMP socket、libvirt 或 `/proc/<pid>/mem`）和一份 guest 内核的 `System.map`，直接读取 guest 物理内存，找到内核的日志缓冲区并把它解码成人类可读的 `dmesg` 输出。
+
+要做到这一点，核心需要解决三个问题：
+
+1. **怎么读到 guest 内存？**
+2. **内核加载地址是随机的（KASLR），怎么知道符号在内存里的实际位置？**
+3. **找到日志缓冲区后，怎么按内核版本解析里面的记录？**
+
+下面按顺序讲。
+
+## 2. 整体流程
+
+```text
++-----------------+     +---------------------+     +------------------+
+| System.map      |     | QEMU / libvirt      |     | guest physical   |
+| (符号链接地址)   |     | (CR3 / IDTR / 内存)  |     | memory           |
++--------+--------+     +----------+----------+     +--------+---------+
+         |                         |                          |
+         |                         v                          |
+         |              +----------------------+               |
+         |              | 计算 KASLR 偏移       |               |
+         |              | (kaslr_offset /      |               |
+         |              |  phys_base /         |               |
+         |              |  kimage_voffset)     |               |
+         |              +----------+-----------+               |
+         |                         |                          |
+         v                         v                          v
+   +-----------------------------------------------+          |
+   | 用 System.map 符号地址 - KASLR 偏移得到运行时地址  |          |
+   +-----------------------------------------------+          |
+                          |                                   |
+                          v                                   |
+   +-----------------------------------------------+          |
+   | 把内核虚拟地址 (KVADDR) 转成 guest 物理地址 (paddr) |<---------+
+   +-----------------------------------------------+
+                          |
+                          v
+   +-----------------------------------------------+
+   | 读取 log_buf / prb / vmcoreinfo_data 等数据结构  |
+   +-----------------------------------------------+
+                          |
+                          v
+   +-----------------------------------------------+
+   | 解析 printk 记录格式并输出                      |
+   +-----------------------------------------------+
+```
+
+## 3. 读取 guest 内存
+
+`client.c` 把底层访问方式抽象成一套接口：
+
+- `get_registers(idtr, cr3, cr4)`：获取 CPU 寄存器（仅 x86_64 需要）。
+- `readmem(paddr, buf, size)`：按 guest 物理地址读取内存。
+
+具体有三种 backend：
+
+| 方式 | 怎么拿到 pid / 寄存器 | 怎么读内存 |
+|------|----------------------|-----------|
+| QMP socket | 通过 socket inode 在 `/proc` 里找到 QEMU pid；QMP `info registers` 取寄存器 | 优先用 `/proc/<pid>/mem` + `gpa2hva`；失败则回退到 QMP `xp` 命令 |
+| libvirt domain | libvirt API 取 pid 和寄存器 | 同上，可回退到 libvirt 的内存 API |
+| memory dump 文件 | 直接从文件读，寄存器由调用方/文件提供 | 直接文件映射/读取 |
+
+> 为什么优先用 `/proc/<pid>/mem`？
+> 因为 QMP 的 `xp` 命令一次只能读一小段，大数据量时非常慢；直接读 QEMU 进程的虚拟地址空间最快。
+
+## 4. x86_64：从 CR3 / IDTR 算出 KASLR
+
+### 4.1 为什么需要 CR3 和 IDTR
+
+x86_64 Linux 内核编译时的链接地址是固定的，但启动时因为 KASLR 会被随机平移。要读任何内核符号，必须先知道这个平移量 `kaslr_offset`。
+
+`CR3` 指向当前 CPU 的页表根（物理地址），`IDTR` 指向中断描述符表 IDT 的**虚拟地址**。IDT 本身在内核里，所以通过它可以验证内核的实际加载位置。
+
+### 4.2 计算过程（在 `arch/x86_64.c` 中）
+
+1. **拿到页表根**
+   ```c
+   pgd = cr3 & ~(CR3_PCID_MASK | PTI_USER_PGTABLE_MASK);
+   ```
+   去掉 PCID 和 PTI 用户页表位，得到真正的内核页目录物理地址。
+
+2. **把 IDTR 虚拟地址翻译成物理地址**
+   用刚刚得到的页表根 walk 页表，得到 `idtr_paddr`。这里走的是正常的 4 级页表。
+
+3. **读 IDT 第 0 号门（divide_error）**
+   IDT[0] 指向 `divide_error`（较新内核是 `asm_exc_divide_error`）处理函数。从 IDT 条目中拼出它的**运行时虚拟地址** `divide_error_vmcore`。
+
+4. **算 KASLR 偏移**
+   `System.map` 里记录了 `divide_error` 的**链接地址** `divide_error_vmlinux`。
+   ```c
+   kaslr_offset = divide_error_vmcore - divide_error_vmlinux;
+   ```
+   如果内核没有随机化，这个值就是 0。
+
+5. **算 phys_base**
+   `System.map` 里还有 `idt_table` 的链接地址。IDT 在物理内存里的位置也可以从 `idtr_paddr` 得到，从而推出内核映像的物理基址：
+   ```c
+   phys_base = idtr_paddr -
+       (idt_table_vmlinux + kaslr_offset - __START_KERNEL_map);
+   ```
+   `__START_KERNEL_map` 是内核映像虚拟区的起始地址（`0xffffffff80000000`）。
+
+### 4.3 读内存时的地址翻译
+
+拿到 `kaslr_offset` 和 `phys_base` 后，任何内核虚拟地址都能转成物理地址：
+
+- **内核映像区**（`>= __START_KERNEL_map`）：
+  ```c
+  paddr = (kvaddr - __START_KERNEL_map) + phys_base;
+  ```
+- **直接映射区/线性区**（低于 `__START_KERNEL_map`）：
+  ```c
+  paddr = kvaddr - PAGE_OFFSET;
+  ```
+  新内核的 `PAGE_OFFSET` 从 `page_offset_base` 符号动态获得。
+
+这就是 `arch_kvtop()` 在 x86_64 下做的事情。
+
+## 5. AArch64：没有页表寄存器怎么办
+
+### 5.1 为什么不能像 x86 那样 walk 页表
+
+QEMU 的 human monitor 命令在 AArch64 上**不暴露 `TTBR1_EL1`**，所以无法从 CR3 等价物拿到内核页表根。因此必须找别的办法把虚拟地址映射到物理地址。
+
+### 5.2 扫描 vmcoreinfo
+
+Linux 内核在 `vmcoreinfo` 里保存了一组崩溃转储时需要的关键常量和偏移。`kvm-dmesg` 在 guest 物理内存里扫描 `OSRELEASE=` 字符串，找到 `vmcoreinfo` 的一份拷贝，并验证它包含 `NUMBER(kimage_voffset)=`。
+
+从这份数据里能直接拿到两个关键值：
+
+- `kimage_voffset`：内核虚拟地址与物理地址的固定差值（`va - pa`）。
+- `KERNELOFFSET`：KASLR 的随机化偏移量。
+
+### 5.3 计算 KIMAGE_VADDR 与 phys_base
+
+```c
+kimage_vaddr = (_text + KERNELOFFSET) 向下对齐到 2 MB;
+phys_base    = kimage_vaddr - kimage_voffset;
+```
+
+`_text` 来自 `System.map`，是内核映像的链接起始地址。
+
+### 5.4 AArch64 的地址翻译
+
+在 `arch/aarch64.c` 的 `aarch64_kvtop()` 里：
+
+- **内核映像区**（`>= kimage_vaddr`）：
+  ```c
+  paddr = kvaddr - kimage_voffset;
+  ```
+- **线性映射区**（`>= PAGE_OFFSET`，通常是 `0xffff800000000000`）：
+  ```c
+  paddr = kvaddr - PAGE_OFFSET;
+  ```
+- **vmalloc / modules 等区域**：同样用 `kimage_voffset` 平移。
+
+这样即使不做页表 walk，也能覆盖 dmesg 相关符号所在的区域。
+
+## 6. 找到并解析日志缓冲区
+
+地址翻译问题解决后，剩下的就是定位日志数据结构并按内核版本解析。
+
+### 6.1 需要的符号
+
+`symbols.c` 从 `System.map` 里只加载会用到的符号，主要包括：
+
+- `log_buf`、`log_buf_len`
+- `log_first_idx`、`log_next_idx`
+- `prb`
+- `vmcoreinfo_data`、`vmcoreinfo_size`
+- `page_offset_base`
+- x86_64 专用：`divide_error` / `asm_exc_divide_error`、`idt_table`
+- AArch64 专用：`kimage_voffset`、`_text` / `_stext`
+
+读取符号数据时，会先用 KASLR 偏移把链接地址修正成运行时地址，再调用 `readmem(KVADDR, ...)` 读内存。
+
+### 6.2 三种 printk 记录格式
+
+`main.c` 和 `printk.c` 按符号存在情况选择解析方式：
+
+#### A. 最老的内核：原始 `log_buf`
+
+直接把 `log_buf` 指向的内存按字符数组打印，遇到 `\0` 换行。适用于非常老的内核。
+
+#### B. 可变长度记录（`struct log`）
+
+内核 3.x ~ 5.x 左右使用。每个记录头包含：
+
+- `ts_nsec`：纳秒时间戳
+- `len`：整个记录长度
+- `text_len`：文本长度
+
+通过 `log_first_idx` / `log_next_idx` 在环形缓冲区上遍历，按记录头切分文本。
+
+#### C. 无锁 printk ringbuffer（`prb`）
+
+较新内核（5.10+，取决于发行版）使用 `printk_ringbuffer`。它分成两部分：
+
+- **desc_ring**：描述符环，每个描述符保存一条记录的元数据（包括 `text_blk_lpos`）。
+- **text_data_ring**：实际文本数据环。
+
+`vmcoreinfo` 里保存了这些结构的大小和成员偏移：`SIZE(printk_ringbuffer)`、`OFFSET(prb_desc_ring)`、`SIZE(prb_desc)`、`OFFSET(printk_info.text_len)` 等等。`dump_lockless_record_log()` 先读 `prb`，再依次读 desc_ring、info_ring、text_data_ring，最后按 ID 从 tail 到 head 遍历输出。
+
+### 6.3 版本信息
+
+`kernel_init()` 从 `vmcoreinfo` 的 `OSRELEASE=` 字段解析出内核版本（例如 `6.6.119-...`），打印在日志最前面：
+
+```text
+Linux version: v6.6.119
+```
+
+## 7. 输出
+
+解析每条记录时：
+
+- 把 `ts_nsec` 转换成 `[ 123.456789]` 格式的时间戳。
+- 对文本中的不可打印字符用 `.` 替换。
+- 保持原有的换行。
+
+最终输出与 guest 里 `dmesg` 看到的内容基本一致。
+
+## 8. x86_64 与 AArch64 对比
+
+| 步骤 | x86_64 | AArch64 |
+|------|--------|---------|
+| 获取寄存器 | QMP/libvirt `info registers` 取 CR3 / IDTR | 不需要 |
+| 计算 KASLR | 用 IDT[0] 实际地址 - `divide_error` 符号地址 | 从 vmcoreinfo 读 `KERNELOFFSET` |
+| 地址翻译 | `phys_base` + `PAGE_OFFSET` | `kimage_voffset` + `PAGE_OFFSET` |
+| 页表 walk | 需要，仅用于把 IDTR 翻译成物理地址 | 不需要 |
+| vmcoreinfo 用途 | 解析 `prb` 结构大小/偏移 + OSRELEASE | 同上，且用于获取 `kimage_voffset` |
+
+## 9. 小结
+
+`kvm-dmesg` 的核心思路可以概括为：
+
+1. 通过 QEMU/libvirt 拿到 CPU 状态（x86_64）或扫描 vmcoreinfo（AArch64），解出 KASLR 和物理基址。
+2. 利用 `System.map` 把符号的链接地址修正为运行时地址。
+3. 把内核虚拟地址按架构规则转成 guest 物理地址并读取。
+4. 根据内核版本选择对应的 printk 数据结构解析并输出。
+
+因为所有信息都来自 host 侧可访问的接口，所以即使 guest 已经 hang 住、没有串口输出，也能把它的内核日志拖出来。

--- a/global_data.c
+++ b/global_data.c
@@ -34,3 +34,6 @@ struct machdep_table *machdep = &machdep_table;
 
 struct offset_table offset_table = { 0 };
 struct size_table size_table = { 0 };
+
+char *vmcoreinfo_buf = NULL;
+size_t vmcoreinfo_size = 0;

--- a/main.c
+++ b/main.c
@@ -28,99 +28,12 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 
+#include "arch.h"
 #include "log.h"
 #include "defs.h"
 #include "client.h"
 #include "version.h"
 #include "printk.h"
-
-struct machine_specific x86_64_machine_specific = { 0 };
-
-static ulong * x86_64_kpgd_offset(ulong kvaddr)
-{
-    ulong *pgd;
-    pgd = ((ulong *)machdep->pgd) + pgd_index(kvaddr);
-    return pgd;
-}
-
-ulong x86_64_pud_offset(ulong pgd_pte, ulong vaddr)
-{
-    ulong *pud;
-    ulong pud_paddr;
-    ulong pud_pte;
-
-    pud_paddr = pgd_pte & PHYSICAL_PAGE_MASK;
-
-    FILL_PUD(pud_paddr, PAGESIZE());
-    pud = ((ulong *)pud_paddr) + pud_index(vaddr);
-    pud_pte = ULONG(machdep->pud + PAGEOFFSET(pud));
-
-    return pud_pte;
-}
-
-ulong x86_64_pmd_offset(ulong pud_pte, ulong vaddr)
-{
-    ulong *pmd;
-    ulong pmd_paddr;
-    ulong pmd_pte;
-
-    pmd_paddr = pud_pte & PHYSICAL_PAGE_MASK;
-
-    FILL_PMD(pmd_paddr, PAGESIZE());
-
-    pmd = ((ulong *)pmd_paddr) + pmd_index(vaddr);
-    pmd_pte = ULONG(machdep->pmd + PAGEOFFSET(pmd));
-    return pmd_pte;
-}
-
-ulong x86_64_pte_offset(ulong pmd_pte, ulong vaddr)
-{
-    ulong *ptep;
-    ulong pte_paddr;
-    ulong pte;
-
-    pte_paddr = pmd_pte & PHYSICAL_PAGE_MASK;
-
-    FILL_PTBL(pte_paddr, PAGESIZE());
-    ptep = ((ulong *)pte_paddr) + pte_index(vaddr);
-    pte = ULONG(machdep->ptbl + PAGEOFFSET(ptep));
-
-    return pte;
-}
-
-int x86_64_kvtop(ulong kvaddr, physaddr_t *paddr)
-{
-    ulong *pgd;
-    ulong pud_pte;
-    ulong pmd_pte;
-    ulong pte;
-
-    pgd = x86_64_kpgd_offset(kvaddr);
-    pud_pte = x86_64_pud_offset(*pgd, kvaddr);
-    pmd_pte = x86_64_pmd_offset(pud_pte, kvaddr);
-    pte = x86_64_pte_offset(pmd_pte, kvaddr);
-    *paddr = (PAGEBASE(pte) & PHYSICAL_PAGE_MASK) + PAGEOFFSET(kvaddr);
-
-    return 0;
-}
-
-ulong get_vec0_addr(ulong idtr)
-{
-    struct gate_struct64 {
-        uint16_t offset_low;
-        uint16_t segment;
-        uint32_t ist : 3, zero0 : 5, type : 5, dpl : 2, p : 1;
-        uint16_t offset_middle;
-        uint32_t offset_high;
-        uint32_t zero1;
-    } __attribute__((packed)) gate;
-
-    readmem(idtr, PHYSADDR, &gate, sizeof(gate));
-
-    return ((ulong)gate.offset_high << 32)
-        + ((ulong)gate.offset_middle << 16)
-        + gate.offset_low;
-}
 
 void write_data_to_file(const char *filename, void *data, size_t size) {
     FILE *file = fopen(filename, "wb");
@@ -135,83 +48,6 @@ void write_data_to_file(const char *filename, void *data, size_t size) {
     }
 
     fclose(file);
-}
-
-#define PTI_USER_PGTABLE_BIT    PAGE_SHIFT
-#define PTI_USER_PGTABLE_MASK   (1 << PTI_USER_PGTABLE_BIT)
-#define CR3_PCID_MASK           0xFFFull
-int calc_kaslr_offset(ulong *kaslr_offset, ulong *phys_base)
-{
-    uint64_t cr3 = 0, idtr = 0, pgd = 0, idtr_paddr;
-    ulong divide_error_vmcore;
-
-    get_cr3_idtr(&cr3, &idtr);
-
-    pgd = cr3 & ~(CR3_PCID_MASK|PTI_USER_PGTABLE_MASK);
-
-    vt->kernel_pgd[0] = pgd;
-    machdep->last_pgd_read = vt->kernel_pgd[0];
-    machdep->machspec->physical_mask_shift = __PHYSICAL_MASK_SHIFT_2_6;
-    machdep->machspec->pgdir_shift = PGDIR_SHIFT;
-    machdep->machspec->ptrs_per_pgd = PTRS_PER_PGD;
-
-    readmem(pgd, PHYSADDR, machdep->pgd, PAGESIZE());
-    x86_64_kvtop(idtr, &idtr_paddr);
-
-    divide_error_vmcore = get_vec0_addr(idtr_paddr);
-    *kaslr_offset = divide_error_vmcore - st->divide_error_vmlinux;
-    *phys_base = idtr_paddr -
-        (st->idt_table_vmlinux + *kaslr_offset - __START_KERNEL_map);
-
-    if (KDEBUG(1)) {
-        pr_debug("kaslr_offset: idtr=%lx", idtr);
-        pr_debug("kaslr_offset: pgd=%lx", pgd);
-        pr_debug("kaslr_offset: idtr(phys)=%lx", idtr_paddr);
-        pr_debug("kaslr_offset: divide_error(vmcore): %lx", divide_error_vmcore);
-        pr_debug("kaslr_offset: kaslr_offset=%lx", *kaslr_offset);
-        pr_debug("kaslr_offset: phys_base   =%lx", *phys_base);
-    }
-
-    return 0;
-}
-
-void x86_64_init()
-{
-    machdep->machspec = &x86_64_machine_specific;
-
-    machdep->pagesize = 4096;
-    machdep->pageoffset = machdep->pagesize - 1;
-    machdep->pagemask = ~((ulonglong)machdep->pageoffset);
-
-    machdep->pgd = malloc(PAGESIZE());
-    machdep->pud = malloc(PAGESIZE());
-    machdep->pmd = malloc(PAGESIZE());
-    machdep->ptbl = malloc(PAGESIZE());
-
-    machdep->machspec->page_offset = PAGE_OFFSET_2_6_27;
-}
-
-void x86_64_post_reloc()
-{
-    if (kernel_symbol_exists("page_offset_base")) {
-        get_symbol_data("page_offset_base", sizeof(ulong),
-            &machdep->machspec->page_offset);
-    }
-}
-
-void derive_kaslr_offset()
-{
-    ulong kaslr_offset = 0;
-    ulong phys_base = 0;
-
-    calc_kaslr_offset(&kaslr_offset, &phys_base);
-
-    if (kaslr_offset) {
-        kt->relocate = kaslr_offset * -1;
-        kt->flags |= RELOC_SET;
-    }
-
-    machdep->machspec->phys_base = phys_base;
 }
 
 int ascii(int c)
@@ -401,6 +237,8 @@ int main(int argc, char *argv[])
     char *symmap_file = NULL;
     char *guest_ac = NULL;
     guest_access_t ac_type;
+    ulong kaslr_offset = 0;
+    ulong phys_base = 0;
     int ind;
 
     pc->debug = 0;
@@ -454,10 +292,24 @@ int main(int argc, char *argv[])
 
     if (guest_client_new(guest_ac, ac_type))
         return -1;
+
     symtab_init(symmap_file);
-    x86_64_init();
-    derive_kaslr_offset();
-    x86_64_post_reloc();
+
+    if (arch_init())
+        return -1;
+
+    if (arch_calc_kaslr_offset(&kaslr_offset, &phys_base))
+        return -1;
+
+    if (kaslr_offset) {
+        kt->relocate = kaslr_offset * -1;
+        kt->flags |= RELOC_SET;
+    }
+
+    machdep->machspec->phys_base = phys_base;
+
+    if (arch_post_reloc())
+        return -1;
 
     vmcoreinfo_init();
     kernel_init();

--- a/mem.c
+++ b/mem.c
@@ -46,6 +46,7 @@ int mem_init(pid_t pid, int (*gpa2hva)(uint64_t, uint64_t*))
     }
 
     proc_mem->mem_fd = fd;
+    proc_mem->pid = pid;
     proc_mem->gpa2hva = gpa2hva;
 
     return 0;
@@ -93,4 +94,130 @@ int mem_read(uint64_t addr, void *buffer, size_t size)
     }
 
     return 0;
+}
+
+
+/*
+ * Simple memmem replacement that does not require _GNU_SOURCE.
+ */
+static void *mem_mem(const void *haystack, size_t haystack_len,
+                     const void *needle, size_t needle_len)
+{
+    const char *h = haystack;
+    const char *n = needle;
+
+    if (needle_len == 0 || haystack_len < needle_len)
+        return NULL;
+
+    for (size_t i = 0; i <= haystack_len - needle_len; i++) {
+        if (memcmp(h + i, n, needle_len) == 0)
+            return (void *)(h + i);
+    }
+    return NULL;
+}
+
+/*
+ * Scan QEMU's guest RAM (via /proc/<pid>/mem) to find a copy of vmcoreinfo.
+ * This is needed on AArch64 where QEMU does not expose TTBR1_EL1 through the
+ * monitor interface, so we cannot do a page table walk.  vmcoreinfo contains
+ * kimage_voffset and KERNELOFFSET which are sufficient to translate kernel
+ * virtual addresses to guest physical addresses.
+ */
+int mem_scan_vmcoreinfo(char *buf, size_t buf_size)
+{
+    char maps_path[64];
+    FILE *maps_fp;
+    char line[512];
+    uint64_t hva_start = 0, hva_end = 0;
+    int found_region = 0;
+    int mem_fd;
+
+    if (!proc_mem || proc_mem->pid <= 0)
+        return -1;
+
+    snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", proc_mem->pid);
+    maps_fp = fopen(maps_path, "r");
+    if (!maps_fp)
+        return -1;
+
+    while (fgets(line, sizeof(line), maps_fp)) {
+        if (strstr(line, "memory-backend-memfd")) {
+            if (sscanf(line, "%lx-%lx", &hva_start, &hva_end) == 2) {
+                found_region = 1;
+                break;
+            }
+        }
+    }
+    fclose(maps_fp);
+
+    if (!found_region) {
+        pr_err("Could not find guest RAM region in /proc/%d/maps", proc_mem->pid);
+        return -1;
+    }
+
+    mem_fd = proc_mem->mem_fd;
+
+#define VMCORE_SCAN_CHUNK (1 << 20)
+#define VMCORE_MAX_SIZE   (1 << 12)
+    char *chunk = malloc(VMCORE_SCAN_CHUNK + VMCORE_MAX_SIZE);
+    if (!chunk)
+        return -1;
+
+    int ret = -1;
+    const char *needle = "OSRELEASE=";
+    const char *valid_marker = "NUMBER(kimage_voffset)=";
+    size_t needle_len = strlen(needle);
+    size_t marker_len = strlen(valid_marker);
+    uint64_t pos = hva_start;
+
+    while (pos + VMCORE_MAX_SIZE < hva_end) {
+        size_t to_read = VMCORE_SCAN_CHUNK;
+        if (pos + to_read > hva_end)
+            to_read = hva_end - pos;
+
+        if (lseek(mem_fd, pos, SEEK_SET) == (off_t)-1) {
+            pos += VMCORE_SCAN_CHUNK;
+            continue;
+        }
+
+        ssize_t n = xread(mem_fd, chunk, to_read + VMCORE_MAX_SIZE);
+        if (n < (ssize_t)needle_len) {
+            pos += VMCORE_SCAN_CHUNK;
+            continue;
+        }
+
+        size_t search_len = (n > VMCORE_SCAN_CHUNK) ? VMCORE_SCAN_CHUNK : n;
+        char *p = chunk;
+        while ((p = mem_mem(p, search_len - (p - chunk), needle, needle_len)) != NULL) {
+            size_t offset = p - chunk;
+            size_t copy_len = VMCORE_MAX_SIZE;
+            if (offset + copy_len > (size_t)n)
+                copy_len = n - offset;
+            if (copy_len > buf_size)
+                copy_len = buf_size;
+
+            /*
+             * vmcoreinfo has several copies in RAM.  Keep looking until we
+             * find one that contains kimage_voffset.
+             */
+            if (copy_len > marker_len &&
+                mem_mem(p, copy_len, valid_marker, marker_len)) {
+                memcpy(buf, p, copy_len);
+                if (copy_len < buf_size)
+                    buf[copy_len] = '\0';
+                ret = 0;
+                break;
+            }
+            p += needle_len;
+        }
+        if (ret == 0)
+            break;
+
+        pos += VMCORE_SCAN_CHUNK;
+    }
+
+    free(chunk);
+    return ret;
+#undef VMCORE_SCAN_CHUNK
+#undef VMCORE_MAX_SIZE
 }

--- a/mem.h
+++ b/mem.h
@@ -20,11 +20,13 @@
 
 typedef struct {
     int mem_fd;
+    pid_t pid;
     int (*gpa2hva)(uint64_t gpa, uint64_t *hva);
 } proc_mem_t;
 
 int mem_init(pid_t pid, int (*gpa2hva)(uint64_t, uint64_t*));
 int mem_uninit();
 int mem_read(uint64_t addr, void *buffer, size_t size);
+int mem_scan_vmcoreinfo(char *buf, size_t buf_size);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,20 @@ cflags = ['-Wall', '-Wextra', '-O2']
 # Linker options
 ldflags = ['-ldl']
 
+# Architecture-specific source
+host_arch = host_machine.cpu_family()
+if host_arch == 'x86_64'
+  arch_src = 'arch/x86_64.c'
+elif host_arch == 'aarch64'
+  arch_src = 'arch/aarch64.c'
+else
+  error('unsupported architecture: ' + host_arch)
+endif
+
 # Sources
 sources = [
   'main.c',
+  arch_src,
   'log.c',
   'version.c',
   'kernel.c',
@@ -26,6 +37,6 @@ sources = [
 # Build executable
 executable('kvm-dmesg',
   sources,
-  c_args       : cflags,
-  link_args    : ldflags
+  c_args    : cflags,
+  link_args : ldflags
 )

--- a/printk.c
+++ b/printk.c
@@ -38,8 +38,6 @@ enum desc_state {
     desc_reusable	= 0x3,	/* free, not yet used by any writer */
 };
 
-static char *vmcoreinfo_buf = NULL;
-
 char *vmcoreinfo_read_string(const char *key)
 {
     const char *buf = vmcoreinfo_buf;
@@ -89,14 +87,24 @@ long datatype_info(char *name, char *member, int datatype)
 void vmcoreinfo_init()
 {
     char *buf;
-    size_t vmcoreinfo_size;
-    ulong vmcoreinfo_data;
+    ulong vmcoreinfo_data_sym;
     ulong osrelease;
 
-    // ASCII value of "OSRELEAS"
-    // crash> rd vmcoreinfo_data 1
-    // ffffffffbd56ca60:  5341454c4552534f                    OSRELEAS
-    osrelease=0x5341454c4552534f;
+    /* ASCII value of "OSRELEAS" */
+    osrelease = 0x5341454c4552534f;
+
+    /* On AArch64 we already scanned vmcoreinfo from guest RAM. */
+    if (vmcoreinfo_buf) {
+        buf = vmcoreinfo_buf;
+        buf[vmcoreinfo_size] = '\n';
+        if (KDEBUG(2)) {
+            for (size_t i = 0; i < vmcoreinfo_size; i++) {
+                fprintf(fp, "%c", buf[i]);
+            }
+            fprintf(fp, "\n");
+        }
+        return;
+    }
 
     get_symbol_data("vmcoreinfo_size", sizeof(vmcoreinfo_size), &vmcoreinfo_size);
     vmcoreinfo_size &= ((1<<13) - 1);
@@ -104,21 +112,19 @@ void vmcoreinfo_init()
     vmcoreinfo_buf = xmalloc(vmcoreinfo_size + 1);
     buf = vmcoreinfo_buf;
 
-    get_symbol_data("vmcoreinfo_data", sizeof(vmcoreinfo_data), &vmcoreinfo_data);
+    get_symbol_data("vmcoreinfo_data", sizeof(vmcoreinfo_data_sym), &vmcoreinfo_data_sym);
 
-    // For legacy kernels like CentOS 3.10.x, the type of vmcoreinfo_data is string array
-    // instead of char pointer, get_symbol_data would simply return the string itself
-    // instead of address, which is not what we want.
-    //
-    // The best way to deal with it is get vmcoreinfo_data data type via tools like
-    // gdb, just like crash utility
-    if (vmcoreinfo_data == osrelease)
-    {
-        vmcoreinfo_data = symbol_value("vmcoreinfo_data");
-        vmcoreinfo_data -= kt->relocate;
+    /*
+     * For legacy kernels like CentOS 3.10.x, the type of vmcoreinfo_data is
+     * string array instead of char pointer, get_symbol_data would simply
+     * return the string itself instead of address, which is not what we want.
+     */
+    if (vmcoreinfo_data_sym == osrelease) {
+        vmcoreinfo_data_sym = symbol_value("vmcoreinfo_data");
+        vmcoreinfo_data_sym -= kt->relocate;
     }
 
-    if (readmem(vmcoreinfo_data, KVADDR, buf, vmcoreinfo_size)) {
+    if (readmem(vmcoreinfo_data_sym, KVADDR, buf, vmcoreinfo_size)) {
         pr_err("cannot read vmcoreinfo_data\n");
         goto err;
     }

--- a/symbols.c
+++ b/symbols.c
@@ -36,7 +36,13 @@ int symbol_needed(const char *symbol)
         "vmcoreinfo_size",
         "page_offset_base",
         "vmalloc_base",
-        "prb"
+        "prb",
+        /* AArch64 specific symbols */
+        "kimage_voffset",
+        "memstart_addr",
+        "swapper_pg_dir",
+        "_text",
+        "_stext"
     };
     size_t array_size = sizeof(symtab_array) / sizeof(symtab_array[0]);
 
@@ -134,7 +140,7 @@ ulong symbol_value(char *symbol)
     struct syment *sp;
 
     if (!(sp = symbol_search(symbol))) {
-        pr_err("cannot resolve symbol");
+        pr_err("cannot resolve symbol: %s", symbol);
         return 0;
     }
 
@@ -157,13 +163,18 @@ void get_symbol_data(char *symbol, long size, void *local)
         readmem(relocate(sp->value), KVADDR, local, size);
     }
     else
-        pr_err("cannot resolve symbol");
+        pr_err("cannot resolve symbol: %s", symbol);
 }
 
 void symtab_init(const char *map_file)
 {
     symname_hash_init(map_file);
 
+#ifdef __aarch64__
+    /* x86-specific exception table symbols are not present on AArch64. */
+    st->divide_error_vmlinux = 0;
+    st->idt_table_vmlinux = 0;
+#else
     if (kernel_symbol_exists("asm_exc_divide_error")) {
         st->divide_error_vmlinux = symbol_value("asm_exc_divide_error");
     } else {
@@ -171,4 +182,5 @@ void symtab_init(const char *map_file)
     }
 
     st->idt_table_vmlinux = symbol_value("idt_table");
+#endif
 }


### PR DESCRIPTION
This PR adds AArch64 guest support while keeping the existing x86_64 path intact.

## Changes

- **arch: introduce architecture abstraction and move x86_64 code to `arch/x86_64.c`**
  - Add `arch.h` / `arch.c` dispatcher (`arch_init`, `arch_calc_kaslr_offset`, `arch_post_reloc`, `arch_kvtop`).
  - Move x86_64 page table walk and KASLR calculation out of `main.c`.
  - Kernel image addresses are translated with `phys_base`; linear-map addresses still use the page table walk.

- **arch: add AArch64 support**
  - Detect guest architecture from QMP / libvirt register info.
  - Implement AArch64 KASLR calculation and address translation using `vmcoreinfo` (QEMU does not expose `TTBR1_EL1`).
  - Add `mem_scan_vmcoreinfo()` to find `kimage_voffset` / `KERNELOFFSET` from guest RAM.
  - Reuse the scanned `vmcoreinfo` buffer so `vmcoreinfo_init()` does not need to read the `vmcoreinfo_data` pointer (which may live in the vmalloc region).

- **docs: update README for AArch64 support**

## Testing

- `make` and `meson compile` pass.
- GitHub Actions x86_64 CI (CentOS 7/8/9/10, RockyLinux 9/10) passes.
- Local AArch64 smoke test with `collei` Nix VM passes:
  ```bash
  ./kvm-dmesg /home/martins3/data/hack/vm/nix/s/qmp-no-pretty /home/martins3/data/hack/vm/nix/System.map
  ```
